### PR TITLE
changed notification onClick from window.open to a window.focus

### DIFF
--- a/index.js
+++ b/index.js
@@ -26,7 +26,9 @@ var Notifier = React.createClass({
           body: context,
         });
         notification.onclick = function() {
-          window.open(url, name);
+            parent.focus();
+            window.focus(); //just in case, older browsers
+            this.close();
         };
       }
     }


### PR DESCRIPTION
Changing to on focus stops a window from being created every time you click the notification, instead it will take you to the tab/window the notification originated from.  😀